### PR TITLE
realizeのインストールに失敗する現象を解消

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN set -x && \
   apk update && \
   apk add --no-cache git && \
   go build -o go-rest-api && \
-  go get -u github.com/oxequa/realize && \
+  go get gopkg.in/urfave/cli.v2@master && \
+  go get github.com/oxequa/realize && \
   go get -u github.com/go-delve/delve/cmd/dlv && \
   go build -o /go/bin/dlv github.com/go-delve/delve/cmd/dlv
 


### PR DESCRIPTION
# issue URL
https://github.com/keitakn/go-rest-api/issues/12

# やった事
暫定処置としてrealizeのインストール前に `gopkg.in/urfave/cli.v2` を追加するように改修